### PR TITLE
DoubleCross_Korean for HC and PCP, PCN

### DIFF
--- a/lib/bcdice/game_system/DoubleCross_Korean.rb
+++ b/lib/bcdice/game_system/DoubleCross_Korean.rb
@@ -24,6 +24,9 @@ module BCDice
         　・감정표（ET）
         　　포지티브와 네거티브 양쪽을 굴려, 겉으로 나타는 쪽에 O를 붙여 표시합니다.
         　　물론 임의로 정하는 부분을 변경해도 괜찮습니다.
+        ・해프닝차트（HC）
+        ・RW프롤로그차트 포지티브（PCP）
+        ・RW프롤로그차트 네거티브（PCN）
         ・D66다이스 있음
       INFO_MESSAGE_TEXT
 
@@ -49,6 +52,11 @@ module BCDice
 
       # 感情表（ネガティブ）
       NEGATIVE_EMOTION_TABLE = negative_emotion_table(:ko_kr).freeze
+
+      HAPPENING_CHART = happening_chart(:ko_kr).freeze
+
+      PROLOGUE_CHART_POSITIVE = prologue_chart_positive(:ko_kr).freeze
+      PROLOGUE_CHART_NEGATIVE = prologue_chart_negative(:ko_kr).freeze
     end
   end
 end


### PR DESCRIPTION
RYOSKATE様のアップデートが通過した場合のダブルクロスKoreanバージョンのアップデート。 FS判定のハプニングチャート(HC)とRWのプロローグチャート(PCP, PCN)を含みます。