### PR TITLE
DoubleCross_Korean.rb

### DIFF
--- a/lib/bcdice/game_system/DoubleCross_Korean.rb
+++ b/lib/bcdice/game_system/DoubleCross_Korean.rb
@@ -52,9 +52,7 @@ module BCDice
 
       # 感情表（ネガティブ）
       NEGATIVE_EMOTION_TABLE = negative_emotion_table(:ko_kr).freeze
-
       HAPPENING_CHART = happening_chart(:ko_kr).freeze
-
       PROLOGUE_CHART_POSITIVE = prologue_chart_positive(:ko_kr).freeze
       PROLOGUE_CHART_NEGATIVE = prologue_chart_negative(:ko_kr).freeze
     end


### PR DESCRIPTION
RYOSKATE様のアップデートが通過した場合のダブルクロスKoreanバージョンのアップデート。 FS判定のハプニングチャートとRWのプロローグチャートを含む。